### PR TITLE
conditionally include SD.h or SdFat.h depending on whether SDFAT is defined

### DIFF
--- a/TMRpcm/TMRpcm.cpp
+++ b/TMRpcm/TMRpcm.cpp
@@ -1,10 +1,13 @@
 /*Library by TMRh20 2012-2014*/
 
 
-#include <SD.h>
-#include <SdFat.h>
-#include <TMRpcm.h>
 #include <pcmConfig.h>
+#if !defined (SDFAT)
+	#include <SD.h>
+#else
+	#include <SdFat.h>
+#endif
+#include <TMRpcm.h>
 
 #if !defined (RF_ONLY)
 

--- a/TMRpcm/TMRpcm.h
+++ b/TMRpcm/TMRpcm.h
@@ -13,8 +13,11 @@ Contributors:
 #include <Arduino.h>
 #include <pcmConfig.h>
 #include <pcmRF.h>
-#include <SD.h>
-#include <SdFat.h>
+#if !defined (SDFAT)
+	#include <SD.h>
+#else
+	#include <SdFat.h>
+#endif
 
 #if defined (ENABLE_RF)
 	class RF24;


### PR DESCRIPTION
SdFat.h should not be #include-d in TMRpcm.h and TMRpcm.cpp if SdFat is not being used. I've added some conditional directives to only include it if SDFAT has been #defined (and only include SD.h if it hasn't).

Prior to Arduino 1.5.7, this wasn't really a problem even if the SdFat library wasn't installed, because a missing header file only resulted in a compiler warning (normally hidden, visible only if you enable verbose compile output). Arduino's gcc was updated in 1.5.7, though, and now the missing header file will generate a fatal error and prevent the library and sketch from compiling; these changes fix the problem.
