### PR TITLE
bugfix: Changing `SdFile` parameter to be passed by reference in `searchMainTags`

### DIFF
--- a/TMRpcm.cpp
+++ b/TMRpcm.cpp
@@ -1330,7 +1330,7 @@ byte TMRpcm::id3Info(const char* filename, char* tagData, byte infoNum){
 boolean TMRpcm::searchMainTags(File xFile, char *datStr){
     xFile.seek(36);
 #else
-unsigned long TMRpcm::searchMainTags(SdFile xFile, char *datStr){
+unsigned long TMRpcm::searchMainTags(SdFile &xFile, char *datStr){
     xFile.seekSet(36);
 #endif
         char dChars[4] = {'d','a','t','a'};

--- a/TMRpcm.h
+++ b/TMRpcm.h
@@ -106,7 +106,7 @@ class TMRpcm
     #if !defined (SDFAT)
         boolean searchMainTags(File xFile, char *datStr);
     #else
-        unsigned long searchMainTags(SdFile xFile, char *datStr);
+        unsigned long searchMainTags(SdFile &xFile, char *datStr);
     #endif
 
     #if defined (ENABLE_MULTI)


### PR DESCRIPTION
While looking to use this library for a project using SdFat I observed several compilation errors regarding use of a deleted constructor when passing the `xFile` parameter in `searchMainTags`. I changed this to a reference parameter and the library builds and worked when tested with a simple recording and saving to disk.